### PR TITLE
fix: Add await to client.connect()

### DIFF
--- a/src/MCPClient.ts
+++ b/src/MCPClient.ts
@@ -170,7 +170,7 @@ export class MCPClient extends MCPClientEventEmitter {
       });
 
       this.transports.push(transport);
-      this.client.connect(transport);
+      await this.client.connect(transport);
     } else {
       throw new Error(`Unknown transport type`);
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3f810cc7-eb31-4509-8368-09c5b28803c8)

My issue was `client.connect` doesn't't wait for the connection to be initialized thus having issue with `callTool` method

After patching it locally, I have solved the issue